### PR TITLE
[GH-4] Add build status badges

### DIFF
--- a/.badgetizr.yml.example
+++ b/.badgetizr.yml.example
@@ -36,7 +36,6 @@ badge_base_branch:
 badge_ci:
   enabled: "false"  # Default: disabled
   settings:
-    color: "purple"
     label: "CI"
     logo: "bitrise"
 
@@ -72,3 +71,4 @@ badge_ready_for_approval:
     label: "Ready"
     logo: "checkmark"
     labelized: "Ready for Approval"  # Optional: auto-manage GitHub/GitLab labels
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,10 @@
 ## Checklist
 - [ ] The PR starts by `[GH-XXX] Something clear for the git history` where GH-XXX is replaced by the Github Issue ID created before.
 - [ ] I have added WIP to my PR title and everything is fine (Badge + Label)
-- [ ] I have tested on the [GitLab test project](https://gitlab.com/chris-saez/badgetizr-integration) 
+- [ ] I have tested on the [GitLab test project](https://gitlab.com/chris-saez/badgetizr-integration) and **added the GitLab MR link below for reviewer verification**
+
+## GitLab Testing
+<!-- If you tested on GitLab, please provide the merge request link here -->
+**GitLab MR Link**: [Add your GitLab merge request URL here]
+
+> **Note for Reviewers**: Please verify the GitLab integration works correctly by checking the provided merge request link above. 

--- a/.github/workflows/badgetizr.yml
+++ b/.github/workflows/badgetizr.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Run Badgetizr
+      - name: Run Badgetizr - Started
         uses: aiKrice/homebrew-badgetizr@2.1.0
         with:
           pr_id: ${{ github.event.pull_request.number }}
@@ -25,5 +25,33 @@ jobs:
           pr_destination_branch: ${{ github.event.pull_request.base.ref }}
           pr_build_number: ${{ github.run_id }}
           pr_build_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ci_status: "started"
+          ci_text: "Running Badgetizr"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Badgetizr - Success
+        if: success()
+        uses: aiKrice/homebrew-badgetizr@2.1.0
+        with:
+          pr_id: ${{ github.event.pull_request.number }}
+          configuration: .badgetizr.yml
+          pr_destination_branch: ${{ github.event.pull_request.base.ref }}
+          pr_build_number: ${{ github.run_id }}
+          pr_build_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ci_status: "passed"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Badgetizr - Failed
+        if: failure()
+        uses: aiKrice/homebrew-badgetizr@2.1.0
+        with:
+          pr_id: ${{ github.event.pull_request.number }}
+          configuration: .badgetizr.yml
+          pr_destination_branch: ${{ github.event.pull_request.base.ref }}
+          pr_build_number: ${{ github.run_id }}
+          pr_build_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ci_status: "failed"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,12 @@ We welcome contributions to Badgetizr! Whether you're fixing bugs, adding featur
 - Check that configuration parsing handles edge cases
 - Test authentication with different token types
 
+#### GitLab Integration Testing
+For detailed instructions on testing Badgetizr with GitLab CI/CD:
+- **Full GitLab testing guide**: See [`GITLAB-TESTING.md`](./GITLAB-TESTING.md) in this repository
+- **Test project**: Use the [GitLab test project](https://gitlab.com/chris-saez/badgetizr-integration) for integration testing
+- **CI/CD Pipeline**: Follow the provided `.gitlab-ci.yml` template to test merge request workflows
+
 ### Pull Request Process
 
 **Important**: When opening a pull request, you must generate badges in your own PR by running Badgetizr locally:

--- a/GITLAB-TESTING.md
+++ b/GITLAB-TESTING.md
@@ -1,0 +1,200 @@
+# Testing Badgetizr on GitLab
+
+This guide explains how to test Badgetizr on GitLab using GitLab CI/CD pipelines.
+
+## Prerequisites
+
+1. **GitLab Project**: You need a GitLab repository where you can create merge requests
+2. **GitLab Access Token**: A personal access token with `api` scope to interact with merge requests
+3. **Project Variables**: Configure `GITLAB_ACCESS_TOKEN` in your GitLab project settings
+
+## Setup Instructions
+
+### 1. Configure GitLab Access Token
+
+1. Go to **GitLab** → **Settings** → **Access Tokens**
+2. Create a new token with `api` scope
+3. In your GitLab project, go to **Settings** → **CI/CD** → **Variables**
+4. Add a new variable:
+   - **Key**: `GITLAB_ACCESS_TOKEN`
+   - **Value**: Your personal access token
+   - **Protected**: ❌ (must be unchecked to work with merge request pipelines)
+   - **Masked**: ✅ (recommended for security)
+
+> **⚠️ Important**: The `Protected` option **must be disabled** for the token to work properly with merge request pipelines. Protected variables are only available to protected branches, but merge request pipelines run in a different context.
+
+### 2. Create `.gitlab-ci.yml`
+
+Create a `.gitlab-ci.yml` file in your repository root with the following content:
+
+> **⚠️ Important**: Replace `{BRANCH}` with the actual GitHub branch you want to test (e.g., `feat/GH-4_implement_build_status_badges`, `main`, `develop`, etc.)
+
+```yaml
+badgetizr:
+  stage: build
+  image: alpine:latest
+  before_script:
+    - apk add --no-cache curl bash yq jq
+    - curl -sSL "https://gitlab.com/gitlab-org/cli/-/releases/v1.72.0/downloads/glab_1.72.0_linux_amd64.tar.gz" | tar -xz -C /tmp
+    - mv /tmp/bin/glab /usr/local/bin/glab && chmod +x /usr/local/bin/glab
+    - curl -sSL https://github.com/aiKrice/homebrew-badgetizr/archive/refs/heads/{BRANCH}.tar.gz | tar -xz
+    - cd homebrew-badgetizr-*
+  script:
+    # Started status
+    - |
+      ./badgetizr -c .badgetizr.yml \
+      --pr-id=$CI_MERGE_REQUEST_IID \
+      --pr-destination-branch=$CI_MERGE_REQUEST_TARGET_BRANCH_NAME \
+      --pr-build-number=$CI_PIPELINE_ID \
+      --pr-build-url="https://gitlab.com/$CI_PROJECT_PATH/-/pipelines/$CI_PIPELINE_ID" \
+      --ci-status=started \
+      --ci-text="Running Badgetizr" \
+      --provider=gitlab
+
+    # Wait to see the started badge
+    - sleep 5
+
+    # Success status
+    - |
+      ./badgetizr -c .badgetizr.yml \
+      --pr-id=$CI_MERGE_REQUEST_IID \
+      --pr-destination-branch=$CI_MERGE_REQUEST_TARGET_BRANCH_NAME \
+      --pr-build-number=$CI_PIPELINE_ID \
+      --pr-build-url="https://gitlab.com/$CI_PROJECT_PATH/-/pipelines/$CI_PIPELINE_ID" \
+      --ci-status=passed \
+      --provider=gitlab
+  after_script:
+    # Failed status (runs only on failure)
+    - |
+      if [ "$CI_JOB_STATUS" = "failed" ]; then
+        cd homebrew-badgetizr-*
+        ./badgetizr -c .badgetizr.yml \
+        --pr-id=$CI_MERGE_REQUEST_IID \
+        --pr-destination-branch=$CI_MERGE_REQUEST_TARGET_BRANCH_NAME \
+        --pr-build-number=$CI_PIPELINE_ID \
+        --pr-build-url="https://gitlab.com/$CI_PROJECT_PATH/-/pipelines/$CI_PIPELINE_ID" \
+        --ci-status=failed \
+        --provider=gitlab
+      fi
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  variables:
+    GITLAB_TOKEN: $GITLAB_ACCESS_TOKEN
+```
+
+### 3. Create Configuration File
+
+Create a `.badgetizr.yml` file in your repository root:
+
+```yaml
+badge_ci:
+  enabled: "true"
+  settings:
+    label_color: "black"
+    label: "Build"
+    logo: "gitlab"
+    color: "darkgreen"
+
+badge_wip:
+  enabled: "true"
+  settings:
+    color: "yellow"
+    label: "WIP"
+    logo: "vlcmediaplayer"
+
+badge_ready_for_approval:
+  enabled: "true"
+  settings:
+    color: "darkgreen"
+    label: "Ready"
+    logo: "checkmark"
+```
+
+## Testing Process
+
+### 1. Create a Merge Request
+
+1. Create a new branch in your GitLab repository
+2. Make some changes and push the branch
+3. Create a merge request targeting your main branch
+
+### 2. Watch the Pipeline
+
+1. Go to **CI/CD** → **Pipelines** in your GitLab project
+2. You should see a pipeline running for your merge request
+3. The pipeline will execute the Badgetizr job
+
+### 3. Observe Badge Updates
+
+You should see the badges update in real-time on your merge request:
+
+1. **Started**: ![Badge](https://img.shields.io/badge/Running_Badgetizr-ignored?label=Build&color=yellow&logo=gitlab)
+2. **Success**: ![Badge](https://img.shields.io/badge/12345-ignored?label=Build&color=darkgreen&logo=gitlab)
+
+### 4. Test Different Scenarios
+
+#### Test CI Status Progression
+The pipeline will show:
+1. Yellow badge with "Running Badgetizr" text (for 5 seconds)
+2. Green badge with pipeline ID number
+
+#### Test Failure Scenario
+To test the failure scenario, you can temporarily modify the pipeline to force a failure:
+
+```yaml
+# Add this line in the script section to test failure
+- exit 1  # This will cause the job to fail
+```
+
+## Branch Examples
+
+Common branches you might want to test:
+
+- **Latest stable**: `main` or `master`
+- **Development**: `develop`
+- **Feature branch**: `feat/GH-4_implement_build_status_badges`
+- **Specific version**: `v1.5.4`
+
+## Expected Results
+
+When everything works correctly, you should see:
+
+1. **Pipeline runs** only on merge request events
+2. **Badges appear** in the merge request description
+3. **Status progression** from "started" → "passed"
+4. **Clickable badges** that link to the pipeline
+
+## Troubleshooting
+
+### Pipeline doesn't run
+- Check that you're creating a **merge request** (not just pushing to a branch)
+- Verify the `rules` section in your `.gitlab-ci.yml`
+
+### Badges don't appear
+- Verify your `GITLAB_ACCESS_TOKEN` is correctly configured
+- **Check that the variable is NOT protected** (Protected: ❌)
+- Check the pipeline logs for authentication errors
+- Ensure the token has `api` scope
+- Common error: `401 Unauthorized` usually means the token is protected or invalid
+
+### Wrong branch downloaded
+- Double-check you replaced `{BRANCH}` with the actual branch name
+- Verify the branch exists on GitHub
+
+### Dependencies fail to install
+- Check your internet connectivity in the GitLab runner
+- Verify the package URLs are accessible
+
+## Cleanup
+
+After testing, you can:
+1. Remove the `.gitlab-ci.yml` file if not needed for production
+2. Keep the `.badgetizr.yml` for future use
+3. Revoke the access token if no longer needed
+
+## Next Steps
+
+Once testing is successful on GitLab, you can:
+- Adapt the configuration for your production workflows
+- Customize badge settings for your team's needs
+- Integrate with your existing GitLab CI/CD pipelines

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ badgetizr:
 
 ```bash
 # Download latest release
-curl -sSL https://github.com/aiKrice/homebrew-badgetizr/releases/latest/download/badgetizr.tar.gz | tar -xz --strip-components=1
+TAG=$(curl -s https://api.github.com/repos/aiKrice/homebrew-badgetizr/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -L -o badgetizr-latest.tar.gz "https://github.com/aiKrice/homebrew-badgetizr/archive/refs/tags/$TAG.tar.gz"
+tar -xz --strip-components=1 -f badgetizr-latest.tar.gz
 
 # Install dependencies (yq, jq) - supports macOS and Linux only
 ./configure
@@ -166,8 +168,10 @@ badgetizr [options]
 |--------|-------------|---------|
 | `-c <file>`, `--configuration <file>` | Path to configuration file | `.badgetizr.yml` |
 | `--pr-destination-branch <branch>` | Target branch (required for branch badge) | - |
-| `--pr-build-number <number>` | Build number (required for CI badge) | - |
+| `--pr-build-number <number>` | Build number (for passed/failed statuses or static builds) | - |
 | `--pr-build-url <url>` | Build URL (required for CI badge) | - |
+| `--ci-status <status>` | CI status: `started`, `passed`, `warning`, `failed` | - |
+| `--ci-text <text>` | Custom text for CI badge | - |
 | `--provider <provider>` | Force provider (`github` or `gitlab`) | Auto-detected |
 | `-v`, `--version` | Display version | - |
 | `-h`, `--help` | Display help | - |
@@ -235,7 +239,7 @@ Badgetizr supports multiple badge types that can be customized to track differen
 | 🚨 **Hotfix** | Disabled | Automatically detects PRs targeting main/master | ![HOTFIX](https://img.shields.io/badge/HOTFIX-red?logoColor=white&color=red) | ✅ |
 | 📊 **Dynamic** | Disabled | Tracks checklist completion and custom patterns | ![Tests-Done](https://img.shields.io/badge/Tests-Done-darkgreen) | - |
 | 🌿 **Branch** | Disabled | Highlights non-standard target branches | ![Target-main](https://img.shields.io/badge/Target-main-orange) | - |
-| 🚀 **CI** | Disabled | Shows build information with links to CI runs | ![CI-Build-123](https://img.shields.io/badge/CI-Build%20123-purple?logo=github) | - |
+| 🚀 **CI** | Disabled | Shows CI status and build info with clickable links | ![Build-456](https://img.shields.io/badge/456-ignored?label=Build&color=darkgreen&logo=github) | - |
 | ✅ **Ready for Approval** | Disabled | Shows badge when all checkboxes are completed | ![Ready](https://img.shields.io/badge/Ready-darkgreen?logo=checkmark) | ✅ |
 
 ### Configuration

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,12 @@ inputs:
   pr_build_url:
     description: '(Mandatory when CI badge is enabled) Specify the pull request build url'
     required: false
+  ci_status:
+    description: '(Mandatory when CI status badge is enabled) CI status: started, passed, warning, failed'
+    required: false
+  ci_text:
+    description: '(Optional) Custom text for CI status badge. Defaults to status value'
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -57,20 +63,28 @@ runs:
         pr_destination_branch="${{ inputs.pr_destination_branch }}"
         pr_build_number="${{ inputs.pr_build_number }}"
         pr_build_url="${{ inputs.pr_build_url }}"
+        ci_status="${{ inputs.ci_status }}"
+        ci_text="${{ inputs.ci_text }}"
 
-        options=""
+        args=("-c" "$configuration")
         if [ -n "$pr_id" ]; then
-          options="$options --pr-id=$pr_id"
+          args+=("--pr-id=$pr_id")
         fi
         if [ -n "$pr_destination_branch" ]; then
-          options="$options --pr-destination-branch $pr_destination_branch"
+          args+=("--pr-destination-branch" "$pr_destination_branch")
         fi
         if [ -n "$pr_build_number" ]; then
-          options="$options --pr-build-number $pr_build_number"
+          args+=("--pr-build-number" "$pr_build_number")
         fi
         if [ -n "$pr_build_url" ]; then
-          options="$options --pr-build-url $pr_build_url"
+          args+=("--pr-build-url" "$pr_build_url")
+        fi
+        if [ -n "$ci_status" ]; then
+          args+=("--ci-status=$ci_status")
+        fi
+        if [ -n "$ci_text" ]; then
+          args+=("--ci-text" "$ci_text")
         fi
 
-        ./badgetizr -c $configuration $options
+        ./badgetizr "${args[@]}"
       shell: bash

--- a/badgetizr
+++ b/badgetizr
@@ -67,6 +67,18 @@ while getopts "c:hv-:" opt; do
                 provider)
                     forced_provider="${!OPTIND}"; OPTIND=$(( $OPTIND + 1 ))
                     ;;
+                ci-status=*)
+                    ci_status_badge_status="${OPTARG#*=}"
+                    ;;
+                ci-status)
+                    ci_status_badge_status="${!OPTIND}"; OPTIND=$(( $OPTIND + 1 ))
+                    ;;
+                ci-text=*)
+                    ci_status_badge_text="${OPTARG#*=}"
+                    ;;
+                ci-text)
+                    ci_status_badge_text="${!OPTIND}"; OPTIND=$(( $OPTIND + 1 ))
+                    ;;
                 version)
                     echo "$BADGETIZR_VERSION"
                     exit 0
@@ -143,10 +155,10 @@ if [[ -f "$config_file" && -s "$config_file" ]]; then
     branch_badge_label=$(yq e '.badge_base_branch.settings.label // "Target branch"' "$config_file")
 
     ci_badge_enabled=$(yq e '.badge_ci.enabled // "false"' "$config_file")
-    ci_badge_label_color=$(yq e '.badge_ci.settings.label_color // "purple"' "$config_file")
-    ci_badge_color=$(yq e '.badge_ci.settings.color // "purple"' "$config_file")
     ci_badge_label=$(yq e '.badge_ci.settings.label // "CI"' "$config_file")
-    ci_badge_logo=$(yq e '.badge_ci.settings.logo // "🤖"' "$config_file")
+    ci_badge_logo=$(yq e '.badge_ci.settings.logo // "github"' "$config_file")
+    ci_badge_color=$(yq e '.badge_ci.settings.color // "purple"' "$config_file")
+    ci_badge_label_color=$(yq e '.badge_ci.settings.label_color // "black"' "$config_file")
 
     ticket_badge_enabled=$(yq e '.badge_ticket.enabled // "false"' "$config_file")
     ticket_badge_pattern=$(yq e '.badge_ticket.settings.sed_pattern // ".*\\(([^)]+)\\).*"' "$config_file")
@@ -162,6 +174,7 @@ if [[ -f "$config_file" && -s "$config_file" ]]; then
     ready_for_approval_badge_label=$(yq e '.badge_ready_for_approval.settings.label // "Ready"' "$config_file")
     ready_for_approval_badge_logo=$(yq e '.badge_ready_for_approval.settings.logo // "checkmark"' "$config_file")
     ready_for_approval_badge_labelized=$(yq e '.badge_ready_for_approval.settings.labelized // ""' "$config_file")
+
 else
     echo "🔵 $config_file not found. Using default values."
     wip_badge_enabled="true"
@@ -208,21 +221,6 @@ if [ "$ticket_badge_enabled" = "true" ]; then
     fi
 fi
 
-# CI Badge
-if [ "$ci_badge_enabled" = "true" ]; then
-    if [ -z "$ci_badge_build_number" ]; then
-        echo "🔴 Error: --pr-build-number is mandatory. Use -h for help." >&2
-        exit 1
-    fi
-
-    if [ -z "$ci_badge_build_url" ]; then
-        echo "🔴 Error: --pr-build-url is mandatory. Use -h for help." >&2
-        exit 1
-    fi
-
-    ci_badge="[![Static Badge](https://img.shields.io/badge/$ci_badge_label-$ci_badge_build_number-purple?logo=$ci_badge_logo&logoColor=white&labelColor=$ci_badge_label_color&color=$ci_badge_color)]($ci_badge_build_url)"
-    all_badges=$(echo $all_badges $ci_badge)
-fi
 
 # Target Branch Badge 
 if [ "$branch_badge_enabled" = "true" ]; then
@@ -334,8 +332,9 @@ fi
 if [ "$ready_for_approval_badge_enabled" = "true" ]; then
     # Count unchecked checkboxes in PR body
     unchecked_count=$(printf "%s\n" "$pull_request_body" | grep -c "\- \[ \]" 2>/dev/null || echo "0")
+    unchecked_count=$(echo "$unchecked_count" | tr -d '[:space:]')
 
-    if [[ $unchecked_count -gt 0 ]]; then
+    if [[ "$unchecked_count" -gt 0 ]]; then
         echo "🔲 Found $unchecked_count unchecked checkbox(es), PR not ready for approval"
 
         # Remove ready for approval label if configured
@@ -364,6 +363,78 @@ else
     if [[ -n "$ready_for_approval_badge_labelized" && "$ready_for_approval_badge_labelized" != "null" ]]; then
         remove_pr_label "$ci_badge_pull_request_id" "$ready_for_approval_badge_labelized"
     fi
+fi
+
+# CI Badge (unified with status support)
+if [ "$ci_badge_enabled" = "true" ]; then
+    # pr-build-url is always mandatory for CI badge
+    if [ -z "$ci_badge_build_url" ]; then
+        echo "🔴 Error: --pr-build-url is mandatory when CI badge is enabled." >&2
+        exit 1
+    fi
+
+    # If ci-status is provided, we're in status mode
+    if [[ -n "$ci_status_badge_status" ]]; then
+        # Validate status value (only 4 allowed)
+        case "$ci_status_badge_status" in
+            "started")
+                ci_color="yellow"
+                ;;
+            "passed")
+                ci_color="darkgreen"
+                ;;
+            "warning")
+                ci_color="orange"
+                ;;
+            "failed")
+                ci_color="red"
+                ;;
+            *)
+                echo "❌ Error: Invalid CI status '$ci_status_badge_status'. Allowed: started, passed, warning, failed" >&2
+                exit 1
+                ;;
+        esac
+
+        # Determine badge text based on status
+        if [[ "$ci_status_badge_status" == "started" || "$ci_status_badge_status" == "warning" ]]; then
+            # For intermediate statuses, use custom text if provided, otherwise use status
+            if [[ -n "$ci_status_badge_text" ]]; then
+                ci_text="$ci_status_badge_text"
+            else
+                ci_text="$ci_status_badge_status"
+            fi
+        else
+            # For passed/failed, use build number if available, otherwise custom text, otherwise status
+            if [[ -n "$ci_badge_build_number" ]]; then
+                ci_text="$ci_badge_build_number"
+            elif [[ -n "$ci_status_badge_text" ]]; then
+                ci_text="$ci_status_badge_text"
+            else
+                ci_text="$ci_status_badge_status"
+            fi
+        fi
+
+        echo "🔄 Updating CI badge: $ci_status_badge_status ($ci_text)"
+    else
+        # Legacy mode: no status provided, use build number (backward compatibility)
+        if [ -z "$ci_badge_build_number" ]; then
+            echo "🔴 Error: --pr-build-number is mandatory when no --ci-status is provided." >&2
+            exit 1
+        fi
+        ci_color="$ci_badge_color"
+        ci_text="$ci_badge_build_number"
+        echo "🔄 Creating CI badge: build $ci_text"
+    fi
+
+    # Escape text and label for URL
+    ci_text_escaped=$(echo "$ci_text" | sed -E 's/ /_/g; s/-/--/g')
+    ci_label_escaped=$(echo "$ci_badge_label" | sed -E 's/ /_/g; s/-/--/g')
+
+    # Create unified CI badge (always clickable)
+    ci_badge="[![Static Badge](https://img.shields.io/badge/${ci_text_escaped}-ignored?label=${ci_label_escaped}&logo=${ci_badge_logo}&logoColor=white&labelColor=${ci_badge_label_color}&color=${ci_color})]($ci_badge_build_url)"
+    all_badges=$(echo $all_badges $ci_badge)
+
+    echo "✅ CI badge added to badges collection"
 fi
 
 # Add delimiter for next replacement


### PR DESCRIPTION
<!--begin:badgetizr--> 
[![Static Badge](https://img.shields.io/badge/Issue-4-black?logo=github&color=black&labelColor=grey)](https://github.com/aiKrice/homebrew-badgetizr/issues/4) ![Static Badge](https://img.shields.io/badge/Ready-darkgreen?logo=checkmark&logoColor=white&color=darkgreen) [![Static Badge](https://img.shields.io/badge/17991012432-ignored?label=Build&logo=github&logoColor=white&labelColor=black&color=darkgreen)](https://github.com/aiKrice/homebrew-badgetizr/actions/runs/17991012432)
<!--end:badgetizr-->

## Comments
- Add here anything important in the code changes

## Checklist
- [x] The PR starts by `[GH-XXX] Something clear for the git history` where GH-XXX is replaced by the Github Issue ID created before.
- [x] I have added WIP to my PR title and everything is fine (Badge + Label)
- [x] I have tested on the [GitLab test project](https://gitlab.com/chris-saez/badgetizr-integration) 