### PR TITLE
fix: Try Sonnet model for Claude workflow OIDC compatibility

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-sonnet-4-5-20250929'
 


### PR DESCRIPTION
## Problem
Claude Code workflow fails with error:
```
API Error: 400 - This credential is only authorized for use with Claude Code and cannot be used for other API requests.
```

## Attempted Solution
Switch from Opus (`claude-opus-4-1-20250805`) to Sonnet (`claude-sonnet-4-5-20250929`) model to test if the issue is model-specific with OIDC tokens.

## Testing
After merge, test by commenting `@claude` on issue #34.