### PR TITLE
Fix release naming

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -82,7 +82,7 @@ git tag -a "$VERSION" -m "Release $VERSION"
 git push origin "$VERSION" --no-verify
 fail_if_error "Failed to push tag $VERSION"
 echo "🟢 [Step 3/6] Tag pushed, creating GitHub release..."
-gh release create $VERSION --title "Release $VERSION" --generate-notes --verify-tag --latest
+gh release create $VERSION --title "$VERSION" --generate-notes --verify-tag --latest
 fail_if_error "Failed to create GitHub release"
 echo "🟢 [Step 3/6] GitHub release created successfully"
 echo "📦 GitHub Marketplace: Release will appear automatically (action.yml detected)"


### PR DESCRIPTION
## Comments
- Add here anything important in the code changes

## Checklist
- [ ] The PR starts by `[GH-XXX] Something clear for the git history` where GH-XXX is replaced by the Github Issue ID created before.
- [ ] I have added WIP to my PR title and everything is fine (Badge + Label)
- [ ] I have tested on the [GitLab test project](https://gitlab.com/chris-saez/badgetizr-integration) and **added the GitLab MR link below for reviewer verification**

## GitLab Testing
<!-- If you tested on GitLab, please provide the merge request link here -->
**GitLab MR Link**: [Add your GitLab merge request URL here]

> **Note for Reviewers**: Please verify the GitLab integration works correctly by checking the provided merge request link above. 